### PR TITLE
Add photo crop and zoom adjustment before applying

### DIFF
--- a/src/components/PhotoCropModal.css
+++ b/src/components/PhotoCropModal.css
@@ -1,0 +1,103 @@
+.crop-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.crop-modal {
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px;
+  width: 100%;
+  max-width: 360px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.crop-modal-title {
+  font-size: 17px;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin-bottom: 4px;
+  text-align: center;
+}
+
+.crop-modal-subtitle {
+  font-size: 12.5px;
+  color: #888;
+  text-align: center;
+  margin-bottom: 18px;
+  line-height: 1.4;
+}
+
+.crop-viewport {
+  width: 280px;
+  height: 280px;
+  margin: 0 auto;
+  border-radius: 50%;
+  overflow: hidden;
+  position: relative;
+  background: #1a1a1a;
+  cursor: grab;
+  touch-action: none;
+  box-shadow: 0 0 0 4px #fff, 0 0 0 5px #eee;
+}
+
+.crop-viewport:active {
+  cursor: grabbing;
+}
+
+.crop-image {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  max-width: none;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.crop-zoom-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 22px;
+  padding: 0 4px;
+}
+
+.crop-zoom-slider {
+  flex: 1;
+  accent-color: #0095f6;
+  cursor: pointer;
+}
+
+.crop-modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.crop-btn-cancel, .crop-btn-confirm {
+  flex: 1;
+  padding: 10px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+  border: none;
+}
+
+.crop-btn-cancel {
+  background: #efefef;
+  color: #1a1a1a;
+}
+
+.crop-btn-confirm {
+  background: #0095f6;
+  color: #fff;
+}

--- a/src/components/PhotoCropModal.jsx
+++ b/src/components/PhotoCropModal.jsx
@@ -1,0 +1,141 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import './PhotoCropModal.css'
+
+const CONTAINER_SIZE = 280
+const OUTPUT_SIZE = 600
+const MIN_ZOOM = 1
+const MAX_ZOOM = 4
+
+export default function PhotoCropModal({ imageSrc, onConfirm, onCancel }) {
+  const [zoom, setZoom] = useState(1)
+  const [offset, setOffset] = useState({ x: 0, y: 0 })
+  const [naturalSize, setNaturalSize] = useState(null)
+  const imgRef = useRef(null)
+  const dragRef = useRef(null)
+
+  useEffect(() => {
+    const img = new Image()
+    img.onload = () => setNaturalSize({ w: img.naturalWidth, h: img.naturalHeight })
+    img.src = imageSrc
+  }, [imageSrc])
+
+  const baseScale = naturalSize
+    ? Math.max(CONTAINER_SIZE / naturalSize.w, CONTAINER_SIZE / naturalSize.h)
+    : 1
+
+  const clampOffset = useCallback((off, currentZoom) => {
+    if (!naturalSize) return off
+    const scale = baseScale * currentZoom
+    const dispW = naturalSize.w * scale
+    const dispH = naturalSize.h * scale
+    const maxX = Math.max(0, (dispW - CONTAINER_SIZE) / 2)
+    const maxY = Math.max(0, (dispH - CONTAINER_SIZE) / 2)
+    return {
+      x: Math.min(maxX, Math.max(-maxX, off.x)),
+      y: Math.min(maxY, Math.max(-maxY, off.y)),
+    }
+  }, [naturalSize, baseScale])
+
+  const handlePointerDown = (e) => {
+    const point = 'touches' in e ? e.touches[0] : e
+    dragRef.current = { startX: point.clientX, startY: point.clientY, startOffset: offset }
+  }
+
+  const handlePointerMove = (e) => {
+    if (!dragRef.current) return
+    const point = 'touches' in e ? e.touches[0] : e
+    const dx = point.clientX - dragRef.current.startX
+    const dy = point.clientY - dragRef.current.startY
+    const next = {
+      x: dragRef.current.startOffset.x + dx,
+      y: dragRef.current.startOffset.y + dy,
+    }
+    setOffset(clampOffset(next, zoom))
+  }
+
+  const handlePointerUp = () => {
+    dragRef.current = null
+  }
+
+  const handleZoomChange = (e) => {
+    const z = parseFloat(e.target.value)
+    setZoom(z)
+    setOffset(prev => clampOffset(prev, z))
+  }
+
+  const handleConfirm = () => {
+    if (!naturalSize || !imgRef.current) return
+    const canvas = document.createElement('canvas')
+    canvas.width = OUTPUT_SIZE
+    canvas.height = OUTPUT_SIZE
+    const ctx = canvas.getContext('2d')
+    const ratio = OUTPUT_SIZE / CONTAINER_SIZE
+    const scale = baseScale * zoom * ratio
+    const dispW = naturalSize.w * scale
+    const dispH = naturalSize.h * scale
+    const cx = OUTPUT_SIZE / 2 + offset.x * ratio
+    const cy = OUTPUT_SIZE / 2 + offset.y * ratio
+    ctx.drawImage(imgRef.current, cx - dispW / 2, cy - dispH / 2, dispW, dispH)
+    canvas.toBlob(blob => {
+      onConfirm(URL.createObjectURL(blob))
+    }, 'image/jpeg', 0.92)
+  }
+
+  return (
+    <div className="crop-modal-overlay">
+      <div className="crop-modal">
+        <h3 className="crop-modal-title">Ajustar foto</h3>
+        <p className="crop-modal-subtitle">Acerca, aleja o arrastra para encontrar el encuadre ideal</p>
+
+        <div
+          className="crop-viewport"
+          onMouseDown={handlePointerDown}
+          onMouseMove={handlePointerMove}
+          onMouseUp={handlePointerUp}
+          onMouseLeave={handlePointerUp}
+          onTouchStart={handlePointerDown}
+          onTouchMove={handlePointerMove}
+          onTouchEnd={handlePointerUp}
+        >
+          {naturalSize && (
+            <img
+              ref={imgRef}
+              src={imageSrc}
+              alt="Recortar"
+              className="crop-image"
+              style={{
+                width: naturalSize.w * baseScale * zoom,
+                height: naturalSize.h * baseScale * zoom,
+                transform: `translate(-50%, -50%) translate(${offset.x}px, ${offset.y}px)`,
+              }}
+              draggable={false}
+            />
+          )}
+        </div>
+
+        <div className="crop-zoom-row">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#888" strokeWidth="2">
+            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/>
+          </svg>
+          <input
+            type="range"
+            min={MIN_ZOOM}
+            max={MAX_ZOOM}
+            step="0.01"
+            value={zoom}
+            onChange={handleZoomChange}
+            className="crop-zoom-slider"
+          />
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#888" strokeWidth="2">
+            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/>
+          </svg>
+        </div>
+
+        <div className="crop-modal-actions">
+          <button className="crop-btn-cancel" onClick={onCancel}>Cancelar</button>
+          <button className="crop-btn-confirm" onClick={handleConfirm}>Aplicar</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ProfileForm.css
+++ b/src/components/ProfileForm.css
@@ -169,6 +169,27 @@
   opacity: 1;
 }
 
+.photo-adjust-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.55);
+  color: #fff;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.photo-adjust-btn:hover {
+  background: rgba(0,0,0,0.75);
+}
+
 /* Toggle */
 .toggle-label {
   display: flex;

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1,22 +1,44 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
+import PhotoCropModal from './PhotoCropModal'
 import './ProfileForm.css'
 
 export default function ProfileForm({ profile, onChange }) {
   const fileInputRef = useRef(null)
+  const originalPhotoRef = useRef(null)
+  const [cropSrc, setCropSrc] = useState(null)
+
+  const openCropper = (file) => {
+    const url = URL.createObjectURL(file)
+    originalPhotoRef.current = url
+    setCropSrc(url)
+  }
 
   const handlePhotoChange = (e) => {
     const file = e.target.files[0]
     if (!file) return
-    const url = URL.createObjectURL(file)
-    onChange('photoUrl', url)
+    openCropper(file)
+    e.target.value = ''
   }
 
   const handleDrop = (e) => {
     e.preventDefault()
     const file = e.dataTransfer.files[0]
     if (!file || !file.type.startsWith('image/')) return
-    const url = URL.createObjectURL(file)
-    onChange('photoUrl', url)
+    openCropper(file)
+  }
+
+  const handleReadjust = (e) => {
+    e.stopPropagation()
+    if (originalPhotoRef.current) setCropSrc(originalPhotoRef.current)
+  }
+
+  const handleCropConfirm = (croppedUrl) => {
+    onChange('photoUrl', croppedUrl)
+    setCropSrc(null)
+  }
+
+  const handleCropCancel = () => {
+    setCropSrc(null)
   }
 
   const formatNumber = (val) => {
@@ -44,6 +66,11 @@ export default function ProfileForm({ profile, onChange }) {
               <div className="photo-overlay">
                 <span>Cambiar foto</span>
               </div>
+              <button className="photo-adjust-btn" onClick={handleReadjust} title="Ajustar zoom y encuadre">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/>
+                </svg>
+              </button>
             </div>
           ) : (
             <div className="photo-placeholder">
@@ -171,6 +198,14 @@ export default function ProfileForm({ profile, onChange }) {
         </svg>
         Tus datos no se envían a ningún servidor. Todo se procesa localmente en tu navegador.
       </div>
+
+      {cropSrc && (
+        <PhotoCropModal
+          imageSrc={cropSrc}
+          onConfirm={handleCropConfirm}
+          onCancel={handleCropCancel}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Users can now zoom in/out and drag to reposition their profile photo in a circular preview before it's applied, so they can test how the photo looks closer vs farther away across all the mockups. A small adjust button on the uploaded photo lets them reopen the cropper and re-tune the framing from the original image at any time.

https://claude.ai/code/session_01Loe4KD4cHq4kuV8RK7dLBX